### PR TITLE
Add Docker publishing to GitHub Container Registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,14 @@
 Dockerfile
 docker-compose.yml
+.git
+.github
+.circleci
+.vagrant
+.DS_Store
+*.test
+*.out
+tmp/
+packaging/output/
+build/
+vendor/
+coverage.html

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,68 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hunter-io/faktory
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.12'
+
+      - name: Install Redis
+        run: sudo apt-get update && sudo apt-get install -y redis-server
+
+      - name: Install build tools
+        run: make prepare
+
+      - name: Run tests
+        run: make test
+
+  build-and-push:
+    needs: test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=match,pattern=v(.*),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,24 @@
+FROM golang:1.12-alpine AS builder
+
+RUN apk add --no-cache git
+
+RUN go get github.com/benbjohnson/ego/cmd/ego
+RUN go get github.com/jteeuwen/go-bindata/go-bindata
+
+WORKDIR /go/src/github.com/hunter-io/faktory
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go generate github.com/hunter-io/faktory/webui
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /faktory cmd/faktory/daemon.go
+
 FROM alpine:3.8
 RUN apk add --no-cache redis ca-certificates socat
-COPY ./faktory /
+
+COPY --from=builder /faktory /faktory
 
 RUN mkdir -p /root/.faktory/db
 RUN mkdir -p /var/lib/faktory/db


### PR DESCRIPTION
## Summary
- Convert Dockerfile to multi-stage build for CI-friendly builds
- Add GitHub Actions workflow to automatically publish to ghcr.io on master push and version tag pushes
- Workflow runs full test suite before publishing to ensure only tested images reach the registry
- Expand .dockerignore to keep build context lean

## Configuration
- Publishes `ghcr.io/hunter-io/faktory:latest` on push to master
- Publishes version tags (`v0.15.0`, `v0.15.0-1`, etc.) on git tag push
- Uses GitHub's automatic `GITHUB_TOKEN` (no manual secrets needed)
- First push will create private package; enable public access in package settings if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)